### PR TITLE
refactor: remove footer from Dashboard and Rack Visualization pages

### DIFF
--- a/service_catalog/pages/0_Dashboard.py
+++ b/service_catalog/pages/0_Dashboard.py
@@ -234,12 +234,5 @@ def main() -> None:
     except Exception as e:
         display_error("Unexpected error while fetching data centers", str(e))
 
-    # Footer
-    st.markdown("---")
-    st.markdown(
-        f"Connected to Infrahub at `{st.session_state.infrahub_url}` | "
-        f"Branch: `{st.session_state.selected_branch}`"
-    )
-
 
 main()

--- a/service_catalog/pages/3_Rack_Visualization.py
+++ b/service_catalog/pages/3_Rack_Visualization.py
@@ -345,13 +345,6 @@ def main() -> None:
     st.markdown("### Legend - Device Roles")
     render_legend()
 
-    # Footer
-    st.markdown("---")
-    st.markdown(
-        f"Connected to Infrahub at `{st.session_state.infrahub_url}` | "
-        f"Branch: `{st.session_state.selected_branch}`"
-    )
-
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Remove "Connected to Infrahub at..." footer text from:
- pages/0_Dashboard.py
- pages/3_Rack_Visualization.py