### PR TITLE
introduce DcimGenericDeviceType, DcimPhysicalDeviceType, and DcimVirtualDeviceType

### DIFF
--- a/menus/menu-full.yml
+++ b/menus/menu-full.yml
@@ -75,8 +75,8 @@ spec:
 
                 - namespace: Dcim
                   name: DeviceType
-                  label: Device Types
-                  kind: DcimDeviceType
+                  label: All Device Types
+                  kind: DcimGenericDeviceType
                   icon: "mdi:package-variant"
 
     # ===================== LOAD BALANCING =====================
@@ -87,7 +87,6 @@ spec:
       icon: carbon:load-balancer-global
       children:
         data:
-
           - namespace: Loadbalancing
             name: HealthCheck
             label: Health-Checks

--- a/objects/bootstrap/06_device_types.yml
+++ b/objects/bootstrap/06_device_types.yml
@@ -2,7 +2,7 @@
 apiVersion: infrahub.app/v1
 kind: Object
 spec:
-  kind: DcimDeviceType
+  kind: DcimPhysicalDeviceType
   data:
     - name: QFX5220-32CD
       part_number: QFX5220-32CD
@@ -262,18 +262,6 @@ spec:
       full_depth: false
       manufacturer: Edgecore
       platform: Sonic OS
-    - name: C8000V
-      # part_number: null
-      height: 0
-      full_depth: false
-      manufacturer: Cisco
-      platform: Cisco IOS-XE
-    - name: CloudGuard
-      part_number: CloudGuard-Network-Security
-      height: 0
-      full_depth: false
-      manufacturer: Check Point
-      platform: Check Point Gaia
     - name: N77-SUP2E
       part_number: N77-SUP2E
       height: 0
@@ -297,15 +285,25 @@ spec:
       height: 0
       full_depth: false
       manufacturer: Cisco
+---
+apiVersion: infrahub.app/v1
+kind: Object
+spec:
+  kind: DcimVirtualDeviceType
+  data:
+    - name: C8000V
+      # part_number: null
+      manufacturer: Cisco
+      platform: Cisco IOS-XE
+    - name: CloudGuard
+      part_number: CloudGuard-Network-Security
+      manufacturer: Check Point
+      platform: Check Point Gaia
     - name: HA-PROXY
       part_number: HA-PROXY
-      height: 1
-      full_depth: false
       manufacturer: HAProxy Technologies
       platform: Linux
     - name: NGINX
       part_number: NGINX
-      height: 1
-      full_depth: false
       manufacturer: F5 Networks
       platform: Linux

--- a/objects/bootstrap/09_virtual_device_templates.yml
+++ b/objects/bootstrap/09_virtual_device_templates.yml
@@ -7,7 +7,7 @@ spec:
     expand_range: true
   data:
     - template_name: C8000V_EDGE
-      device_type: C8000V
+      device_type: [Cisco, C8000V]
       role: edge
       status: active
       cpu: 2
@@ -26,7 +26,7 @@ spec:
             role: management
 
     - template_name: CloudGuard_EDGE
-      device_type: CloudGuard
+      device_type: [Check Point, CloudGuard]
       role: edge_firewall
       status: active
       cpu: 2
@@ -45,7 +45,7 @@ spec:
             role: customer
 
     - template_name: HA-PROXY
-      device_type: HA-PROXY
+      device_type: [HAProxy Technologies, HA-PROXY]
       platform: Linux
       role: load_balancer
       status: active
@@ -60,7 +60,7 @@ spec:
         member_of_groups:
           - loadbalancers
     - template_name: NGINX
-      device_type: NGINX
+      device_type: [F5 Networks, NGINX]
       platform: Linux
       role: load_balancer
       status: active

--- a/objects/bootstrap/10_physical_device_templates.yml
+++ b/objects/bootstrap/10_physical_device_templates.yml
@@ -7,7 +7,7 @@ spec:
     expand_range: true
   data:
     - template_name: N9K-C9336C-FX2_SPINE
-      device_type: N9K-C9336C-FX2
+      device_type: [Cisco, N9K-C9336C-FX2]
       role: spine
       status: active
       interfaces:
@@ -25,7 +25,7 @@ spec:
             name: mgmt0
             role: management
     - template_name: N9K-C9336C-FX2_LEAF
-      device_type: N9K-C9336C-FX2
+      device_type: [Cisco, N9K-C9336C-FX2]
       role: leaf
       status: active
       interfaces:
@@ -43,7 +43,7 @@ spec:
             name: mgmt0
             role: management
     - template_name: N9K-C9316D-GX_SPINE
-      device_type: N9K-C9316D-GX
+      device_type: [Cisco, N9K-C9316D-GX]
       role: spine
       status: active
       interfaces:
@@ -61,7 +61,7 @@ spec:
             name: mgmt0
             role: management
     - template_name: N9K-C9316D-GX_LEAF
-      device_type: N9K-C9316D-GX
+      device_type: [Cisco, N9K-C9316D-GX]
       role: leaf
       status: active
       interfaces:
@@ -79,7 +79,7 @@ spec:
             name: mgmt0
             role: management
     - template_name: DCS-7280DR3-24-F_SPINE
-      device_type: DCS-7280DR3-24-F
+      device_type: [Arista, DCS-7280DR3-24-F]
       role: spine
       status: active
       interfaces:
@@ -97,7 +97,7 @@ spec:
             name: Management1
             role: management
     - template_name: CCS-720DP-48S-2F_LEAF
-      device_type: CCS-720DP-48S-2F
+      device_type: [Arista, CCS-720DP-48S-2F]
       role: leaf
       status: active
       interfaces:
@@ -115,7 +115,7 @@ spec:
             name: Management1
             role: management
     - template_name: SRX-1500_EDGE_FIREWALL
-      device_type: SRX-1500
+      device_type: [Juniper, SRX-1500]
       role: edge_firewall
       status: active
       interfaces:
@@ -130,7 +130,7 @@ spec:
             name: ge-0/0/[0-3]
             role: leaf
     - template_name: SRX-1500_DC_FIREWALL
-      device_type: SRX-1500
+      device_type: [Juniper, SRX-1500]
       role: dc_firewall
       status: active
       interfaces:
@@ -145,7 +145,7 @@ spec:
             name: ge-0/0/[0-3]
             role: leaf
     - template_name: C9200L-24P-4G_OOB
-      device_type: C9200L-24P-4G
+      device_type: [Cisco, C9200L-24P-4G]
       role: oob
       status: active
       interfaces:
@@ -160,7 +160,7 @@ spec:
             name: mgmt0
             role: management
     - template_name: SCG50R_CONSOLE
-      device_type: SCG50R
+      device_type: [Perle, SCG50R]
       role: console
       status: active
       interfaces:
@@ -172,7 +172,7 @@ spec:
             name: Ethernet[0-1]
             role: management
     - template_name: N9K-C9316D-GX_EDGE
-      device_type: N9K-C9316D-GX
+      device_type: [Cisco, N9K-C9316D-GX]
       role: edge
       status: active
       interfaces:
@@ -190,7 +190,7 @@ spec:
             name: mgmt0
             role: management
     - template_name: 5912-54X-O-AC-F_LEAF
-      device_type: 5912-54X-O-AC-F
+      device_type: [Edgecore, 5912-54X-O-AC-F]
       role: leaf
       status: active
       interfaces:
@@ -208,7 +208,7 @@ spec:
             name: eth0
             role: management
     - template_name: 7726-32X-O_SPINE
-      device_type: 7726-32X-O
+      device_type: [Edgecore, 7726-32X-O]
       role: spine
       status: active
       interfaces:
@@ -314,7 +314,7 @@ spec:
             name: Ethernet124
             role: uplink
     - template_name: QFX5220-32CD_SPINE
-      device_type: QFX5220-32CD
+      device_type: [Juniper, QFX5220-32CD]
       role: spine
       status: active
       interfaces:
@@ -329,7 +329,7 @@ spec:
             name: ge-0/0/[0-3]
             role: leaf
     - template_name: QFX5220-32CD_LEAF
-      device_type: QFX5220-32CD
+      device_type: [Juniper, QFX5220-32CD]
       role: leaf
       status: active
       interfaces:

--- a/objects/bootstrap/11_device_templates_console.yml
+++ b/objects/bootstrap/11_device_templates_console.yml
@@ -7,7 +7,7 @@ spec:
     expand_range: true
   data:
     - template_name: N9K-C9336C-FX2_SPINE
-      device_type: N9K-C9336C-FX2
+      device_type: [Cisco, N9K-C9336C-FX2]
       role: spine
       status: active
       interfaces:
@@ -17,7 +17,7 @@ spec:
             name: con
             role: console
     - template_name: N9K-C9336C-FX2_LEAF
-      device_type: N9K-C9336C-FX2
+      device_type: [Cisco, N9K-C9336C-FX2]
       role: leaf
       status: active
       interfaces:
@@ -27,7 +27,7 @@ spec:
             name: con
             role: console
     - template_name: N9K-C9316D-GX_SPINE
-      device_type: N9K-C9316D-GX
+      device_type: [Cisco, N9K-C9316D-GX]
       role: spine
       status: active
       interfaces:
@@ -37,7 +37,7 @@ spec:
             name: con
             role: console
     - template_name: N9K-C9316D-GX_LEAF
-      device_type: N9K-C9316D-GX
+      device_type: [Cisco, N9K-C9316D-GX]
       role: leaf
       status: active
       interfaces:
@@ -47,7 +47,7 @@ spec:
             name: con
             role: console
     - template_name: DCS-7280DR3-24-F_SPINE
-      device_type: DCS-7280DR3-24-F
+      device_type: [Arista, DCS-7280DR3-24-F]
       role: spine
       status: active
       interfaces:
@@ -57,7 +57,7 @@ spec:
             name: Console
             role: console
     - template_name: CCS-720DP-48S-2F_LEAF
-      device_type: CCS-720DP-48S-2F
+      device_type: [Arista, CCS-720DP-48S-2F]
       role: leaf
       status: active
       interfaces:
@@ -67,7 +67,7 @@ spec:
             name: Console
             role: console
     - template_name: SRX-1500_EDGE_FIREWALL
-      device_type: SRX-1500
+      device_type: [Juniper, SRX-1500]
       role: edge_firewall
       status: active
       interfaces:
@@ -77,7 +77,7 @@ spec:
             name: con
             role: console
     - template_name: C9200L-24P-4G_OOB
-      device_type: C9200L-24P-4G
+      device_type: [Cisco, C9200L-24P-4G]
       role: oob
       status: active
       interfaces:
@@ -87,7 +87,7 @@ spec:
             name: con
             role: console
     - template_name: SCG50R_CONSOLE
-      device_type: SCG50R
+      device_type: [Perle, SCG50R]
       role: console
       status: active
       interfaces:
@@ -99,7 +99,7 @@ spec:
             name: con[0-24]
             role: console
     - template_name: N9K-C9316D-GX_EDGE
-      device_type: N9K-C9316D-GX
+      device_type: [Cisco, N9K-C9316D-GX]
       role: edge
       status: active
       interfaces:

--- a/objects/bootstrap/14_design_elements.yml
+++ b/objects/bootstrap/14_design_elements.yml
@@ -8,131 +8,131 @@ spec:
       description: 2 Cisco C9336C-FX2 spines
       quantity: 2
       role: spine
-      device_type: N9K-C9336C-FX2
+      device_type: [Cisco, N9K-C9336C-FX2]
       template: N9K-C9336C-FX2_SPINE
     - name: 8 CISCO LEAFS N9K-C9336C-FX2
       description: 8 Cisco C9336C-FX2 leafs
       quantity: 8
       role: leaf
-      device_type: N9K-C9336C-FX2
+      device_type: [Cisco, N9K-C9336C-FX2]
       template: N9K-C9336C-FX2_LEAF
     - name: 4 CISCO SPINES N9K-C9316D-GX
       description: 4 Cisco N9K-C9316D-GX spines
       quantity: 4
       role: spine
-      device_type: N9K-C9316D-GX
+      device_type: [Cisco, N9K-C9316D-GX]
       template: N9K-C9316D-GX_SPINE
     - name: 16 CISCO LEAFS N9K-C9316D-GX
       description: 16 Cisco N9K-C9316D-GX leafs
       quantity: 16
       role: leaf
-      device_type: N9K-C9316D-GX
+      device_type: [Cisco, N9K-C9316D-GX]
       template: N9K-C9316D-GX_LEAF
     - name: 2 ARISTA SPINES DCS-7280DR3-24-F
       description: 2 Arista DCS-7280DR3-24-F spines
       quantity: 2
       role: spine
-      device_type: DCS-7280DR3-24-F
+      device_type: [Arista, DCS-7280DR3-24-F]
       template: DCS-7280DR3-24-F_SPINE
     - name: 4 ARISTA LEAFS CCS-720DP-48S-2F
       description: 4 Arista CCS-720DP-48S-2F leafs
       quantity: 4
       role: leaf
-      device_type: CCS-720DP-48S-2F
+      device_type: [Arista, CCS-720DP-48S-2F]
       template: CCS-720DP-48S-2F_LEAF
     - name: 6 ARISTA LEAFS CCS-720DP-48S-2F
       description: 6 Arista CCS-720DP-48S-2F leafs
       quantity: 6
       role: leaf
-      device_type: CCS-720DP-48S-2F
+      device_type: [Arista, CCS-720DP-48S-2F]
       template: CCS-720DP-48S-2F_LEAF
     - name: 2 JUNIPER EDGE FIREWALLS SRX-1500
       description: 2 Juniper EDGE SRX-1500 firewalls
       quantity: 2
       role: edge_firewall
-      device_type: SRX-1500
+      device_type: [F5 Networks, NGINX]
       template: SRX-1500_EDGE_FIREWALL
     - name: 2 JUNIPER DC FIREWALLS SRX-1500
       description: 2 Juniper DC SRX-1500 firewalls
       quantity: 2
       role: dc_firewall
-      device_type: SRX-1500
+      device_type: [F5 Networks, NGINX]
       template: SRX-1500_DC_FIREWALL
     - name: 2 CISCO OOB SWITCHES C9200L-24P-4G
       description: 2 Cisco C9200L-24P-4G OOB switches
       quantity: 2
       role: oob
-      device_type: C9200L-24P-4G
+      device_type: [Cisco, C9200L-24P-4G]
       template: C9200L-24P-4G_OOB
     - name: 2 PERLE CONSOLE SCG50R
       description: 2 Perle SCG50R console servers
       quantity: 2
       role: console
-      device_type: SCG50R
+      device_type: [Perle, SCG50R]
       template: SCG50R_CONSOLE
     - name: 2 CISCO EDGE N9K-C9316D-GX
       description: 2 Cisco N9K-C9316D-GX edges
       quantity: 2
       role: edge
-      device_type: N9K-C9316D-GX
+      device_type: [Cisco, N9K-C9316D-GX]
       template: N9K-C9316D-GX_EDGE
     - name: 2 EDGECORE SPINES 7726-32X-O
       description: 2 EDGECORE 7726-32X-O spines
       quantity: 2
       role: spine
-      device_type: 7726-32X-O
+      device_type: [Edgecore, 7726-32X-O]
       template: 7726-32X-O_SPINE
     - name: 4 EDGECORE LEAFS 5912-54X-O-AC-F
       description: 4 EDGECORE 5912-54X-O-AC-F leafs
       quantity: 4
       role: leaf
-      device_type: 5912-54X-O-AC-F
+      device_type: [Edgecore, 5912-54X-O-AC-F]
       template: 5912-54X-O-AC-F_LEAF
     - name: 2 C8000V EDGES
       description: 2 C8000V edges
       quantity: 2
       role: edge
-      device_type: C8000V
+      device_type: [Cisco, C8000V]
       template: C8000V_EDGE
     - name: 2 CloudGuard Security Edges
       description: 2 CloudGuard Security Edges
       quantity: 2
       role: edge_firewall
-      device_type: CloudGuard
+      device_type: [Check Point, CloudGuard]
       template: CloudGuard_EDGE
     - name: 2 CISCO BORDER LEAFS N9K-C9336C-FX2
       description: 2 Cisco C9336C-FX2 border leafs
       quantity: 2
       role: border_leaf
-      device_type: N9K-C9336C-FX2
+      device_type: [Cisco, N9K-C9336C-FX2]
       template: N9K-C9336C-FX2_LEAF
     - name: 2 CISCO BORDER LEAFS N9K-C9316D-GX
       description: 2 Cisco N9K-C9316D-GX border leafs
       quantity: 2
       role: border_leaf
-      device_type: N9K-C9316D-GX
+      device_type: [Cisco, N9K-C9316D-GX]
       template: N9K-C9316D-GX_LEAF
     - name: 2 ARISTA BORDER LEAFS CCS-720DP-48S-2F
       description: 2 Arista CCS-720DP-48S-2F border leafs
       quantity: 2
       role: border_leaf
-      device_type: CCS-720DP-48S-2F
+      device_type: [Arista, CCS-720DP-48S-2F]
       template: CCS-720DP-48S-2F_LEAF
     - name: 2 EDGECORE BORDER LEAFS 5912-54X-O-AC-F
       description: 2 EDGECORE 5912-54X-O-AC-F border leafs
       quantity: 2
       role: border_leaf
-      device_type: 5912-54X-O-AC-F
+      device_type: [Edgecore, 5912-54X-O-AC-F]
       template: 5912-54X-O-AC-F_LEAF
     - name: 2 JUNIPER SPINES QFX5220-32CD
       description: 2 Juniper QFX5220-32CD spines
       quantity: 2
       role: spine
-      device_type: QFX5220-32CD
+      device_type: [Juniper, QFX5220-32CD]
       template: QFX5220-32CD_SPINE
     - name: 4 JUNIPER LEAFS QFX5220-32CD
       description: 4 Juniper QFX5220-32CD leafs
       quantity: 4
       role: leaf
-      device_type: QFX5220-32CD
+      device_type: [Juniper, QFX5220-32CD]
       template: QFX5220-32CD_LEAF

--- a/objects/bootstrap/18_devices.yml
+++ b/objects/bootstrap/18_devices.yml
@@ -123,3 +123,24 @@ spec:
           - name: Ethernet12
             role: customer
             status: active
+---
+apiVersion: infrahub.app/v1
+kind: Object
+spec:
+  kind: DcimVirtualDevice
+  data:
+    - name: nginx-01
+      role: load_balancer
+      device_type: NGINX
+      platform: Linux
+      status: active
+      cpu: 2
+      memory: 2
+      member_of_groups:
+        - loadbalancers
+      interfaces:
+        kind: InterfaceVirtual
+        data:
+          - name: private
+            role: management
+            status: active

--- a/objects/bootstrap/18_devices.yml
+++ b/objects/bootstrap/18_devices.yml
@@ -6,7 +6,7 @@ spec:
   data:
     - name: corp-firewall
       role: edge_firewall
-      device_type: SRX-1500
+      device_type: [Juniper, SRX-1500]
       platform: Juniper JunOS
       location: PAR-1
       status: active
@@ -39,7 +39,7 @@ spec:
   data:
     - name: cisco-switch-01
       role: leaf
-      device_type: N9K-C93108TC-FX
+      device_type: [Cisco, N9K-C93108TC-FX]
       platform: Cisco NX-OS
       location: LON-1
       status: active
@@ -59,7 +59,7 @@ spec:
 
     - name: juniper-switch-01
       role: spine
-      device_type: QFX5220-32CD
+      device_type: [Juniper, QFX5220-32CD]
       platform: Juniper JunOS
       location: FRA-1
       status: active
@@ -79,7 +79,7 @@ spec:
 
     - name: arista-switch-01
       role: spine
-      device_type: DCS-7280DR3-24-F
+      device_type: [Arista, DCS-7280DR3-24-F]
       platform: Arista EOS
       location: BCN-1
       status: active
@@ -99,7 +99,7 @@ spec:
 
     - name: edgecore-switch-01
       role: leaf
-      device_type: 5912-54X-O-AC-F
+      device_type: [Edgecore, 5912-54X-O-AC-F]
       platform: Sonic OS
       location: CHI-1
       status: active
@@ -131,7 +131,7 @@ spec:
   data:
     - name: nginx-01
       role: load_balancer
-      device_type: NGINX
+      device_type: [F5 Networks, NGINX]
       platform: Linux
       status: active
       cpu: 2

--- a/objects/cloud_security/02_zscaler_devices.yml
+++ b/objects/cloud_security/02_zscaler_devices.yml
@@ -23,7 +23,7 @@ spec:
           name: DC-1
           shortname: DC-1
           parent: Katowice
-      device_type: ZIA-Gateway
+      device_type: [Zscaler, ZIA-Gateway]
       role: edge_firewall
       status: active
       cpu: 4
@@ -46,7 +46,7 @@ spec:
           name: DC-1
           shortname: DC-1
           parent: Katowice
-      device_type: ZIA-Gateway
+      device_type: [Zscaler, ZIA-Gateway]
       role: edge_firewall
       status: active
       cpu: 2
@@ -69,7 +69,7 @@ spec:
           name: DC-1
           shortname: DC-1
           parent: Katowice
-      device_type: ZIA-Gateway
+      device_type: [Zscaler, ZIA-Gateway]
       role: edge_firewall
       status: active
       cpu: 2

--- a/objects/cloud_security/22_cloud_security_device_types.yml
+++ b/objects/cloud_security/22_cloud_security_device_types.yml
@@ -2,7 +2,7 @@
 apiVersion: infrahub.app/v1
 kind: Object
 spec:
-  kind: DcimDeviceType
+  kind: DcimVirtualDeviceType
   data:
     # Zscaler Device Types
     - name: ZIA-Gateway

--- a/objects/lb/00_device_type.yml
+++ b/objects/lb/00_device_type.yml
@@ -2,7 +2,7 @@
 apiVersion: infrahub.app/v1
 kind: Object
 spec:
-  kind: DcimDeviceType
+  kind: DcimVirtualDeviceType
   data:
     - name: HA-PROXY
       part_number: HA-PROXY

--- a/objects/lb/01_lb_templates.yml
+++ b/objects/lb/01_lb_templates.yml
@@ -5,7 +5,7 @@ spec:
   kind: TemplateDcimVirtualDevice
   data:
     - template_name: HA-PROXY
-      device_type: HA-PROXY
+      device_type: [HAProxy Technologies, HA-PROXY]
       platform: Linux
       role: load_balancer
       status: active
@@ -20,7 +20,7 @@ spec:
         member_of_groups:
           - loadbalancers
     - template_name: NGINX
-      device_type: NGINX
+      device_type: [F5 Networks, NGINX]
       platform: Linux
       role: load_balancer
       status: active

--- a/objects/lb/02_lb_devices.yml
+++ b/objects/lb/02_lb_devices.yml
@@ -11,7 +11,7 @@ spec:
           name: DC-1
           shortname: DC-1
           parent: Katowice
-      device_type: HA-PROXY
+      device_type: [HAProxy Technologies, HA-PROXY]
       object_template: HA-PROXY
       status: active
       cpu: 2

--- a/schemas/base/dcim.yml
+++ b/schemas/base/dcim.yml
@@ -342,8 +342,9 @@ generics:
     label: Device Type
     icon: mdi:poll
     human_friendly_id:
+      - manufacturer__name__value
       - name__value
-    display_label: "{{ name__value }}"
+    display_label: "{{ manufacturer__name__value }} {{ name__value }}"
     order_by:
       - manufacturer__name__value
       - name__value

--- a/schemas/base/dcim.yml
+++ b/schemas/base/dcim.yml
@@ -84,7 +84,7 @@ generics:
             description: Device mounted on the rear face of the rack.
     relationships:
       - name: device_type
-        peer: DcimDeviceType
+        peer: DcimPhysicalDeviceType
         optional: true
         cardinality: one
         kind: Attribute
@@ -335,11 +335,10 @@ generics:
         description: "Sub-interfaces of this interface"
         order_weight: 1750
 
-nodes:
-  # --------------------  Device (Types, Platforms, Device, Interfaces )  --------------------
-  - name: DeviceType
+  - name: GenericDeviceType
     namespace: Dcim
-    description: A model of device
+    description: Generic Device Type object
+    include_in_menu: false
     label: Device Type
     icon: mdi:poll
     human_friendly_id:
@@ -364,6 +363,36 @@ nodes:
         optional: true
         kind: Text
         order_weight: 1200
+    relationships:
+      - name: manufacturer
+        peer: OrganizationManufacturer
+        cardinality: one
+        kind: Attribute
+        order_weight: 1250
+        optional: false
+      - name: platform
+        peer: DcimPlatform
+        cardinality: one
+        kind: Attribute
+        order_weight: 1300
+      - name: tags
+        peer: BuiltinTag
+        optional: true
+        cardinality: many
+        kind: Attribute
+        order_weight: 2000
+
+nodes:
+  # --------------------  Device (Types, Platforms, Device, Interfaces )  --------------------
+  - name: PhysicalDeviceType
+    namespace: Dcim
+    description: A model of physical device
+    include_in_menu: false
+    label: Physical Device Type
+    icon: mdi:poll
+    inherit_from:
+      - DcimGenericDeviceType
+    attributes:
       - name: height
         label: Height (U)
         optional: false
@@ -381,23 +410,42 @@ nodes:
         kind: Number
         order_weight: 1600
     relationships:
-      - name: platform
-        peer: DcimPlatform
-        cardinality: one
-        kind: Attribute
-        order_weight: 1300
-      - name: manufacturer
-        peer: OrganizationManufacturer
-        cardinality: one
-        kind: Attribute
-        order_weight: 1250
-        optional: false
-      - name: tags
-        peer: BuiltinTag
+      - name: devices
+        peer: DcimPhysicalDevice
         optional: true
         cardinality: many
-        kind: Attribute
+        order_weight: 1350
+
+  - name: VirtualDeviceType
+    namespace: Dcim
+    description: A model of virtual device
+    include_in_menu: false
+    label: Virtual Device Type
+    icon: mdi:poll
+    inherit_from:
+      - DcimGenericDeviceType
+    attributes:
+      - name: cpu
+        label: CPU Number
+        kind: Number
+        optional: true
         order_weight: 2000
+      - name: memory
+        label: Memory Size (GB)
+        kind: Number
+        optional: true
+        order_weight: 2100
+      - name: storage
+        label: Storage Size (GB)
+        kind: Number
+        optional: true
+        order_weight: 2200
+    relationships:
+      - name: devices
+        peer: DcimVirtualDevice
+        optional: true
+        cardinality: many
+        order_weight: 1350
 
   - name: Platform
     namespace: Dcim
@@ -616,7 +664,7 @@ nodes:
         order_weight: 2200
     relationships:
       - name: device_type
-        peer: DcimDeviceType
+        peer: DcimVirtualDeviceType
         optional: true
         cardinality: one
         kind: Attribute

--- a/schemas/base/organization.yml
+++ b/schemas/base/organization.yml
@@ -54,7 +54,7 @@ nodes:
         order_weight: 1200
     relationships:
       - name: device_type
-        peer: DcimDeviceType
+        peer: DcimGenericDeviceType
         cardinality: many
         optional: true
       - name: platform

--- a/schemas/base/topology.yml
+++ b/schemas/base/topology.yml
@@ -235,7 +235,7 @@ nodes:
     relationships:
       - name: device_type
         label: Type
-        peer: DcimDeviceType
+        peer: DcimGenericDeviceType
         optional: false
         cardinality: one
         kind: Attribute
@@ -324,7 +324,7 @@ nodes:
     inherit_from:
       - NetworkManagementServer
 
-#   --------------------  Topology  Deployments --------------------
+  #   --------------------  Topology  Deployments --------------------
   - name: DataCenter
     namespace: Topology
     description: "A Topology represents the entire network pod."
@@ -436,7 +436,7 @@ nodes:
 
 extensions:
   nodes:
-    - kind: DcimDeviceType
+    - kind: DcimGenericDeviceType
       relationships:
         - name: design_components
           peer: DesignElement

--- a/schemas/extensions/topology/topology.yml
+++ b/schemas/extensions/topology/topology.yml
@@ -3,7 +3,7 @@
 version: "1.0"
 extensions:
   nodes:
-    - kind: DcimDeviceType
+    - kind: DcimGenericDeviceType
       relationships:
         - name: design_components
           peer: DesignElement

--- a/tests/integration/data/bootstrap/06_device_types.yml
+++ b/tests/integration/data/bootstrap/06_device_types.yml
@@ -2,7 +2,7 @@
 apiVersion: infrahub.app/v1
 kind: Object
 spec:
-  kind: DcimDeviceType
+  kind: DcimPhysicalDeviceType
   data:
     # UNUSED: Juniper MX204 not used in integration tests (QFX5220-32CD is used in objects/bootstrap version)
     # - name: MX204

--- a/tests/integration/data/bootstrap/09_virtual_device_templates.yml
+++ b/tests/integration/data/bootstrap/09_virtual_device_templates.yml
@@ -5,7 +5,7 @@ spec:
   kind: TemplateDcimVirtualDevice
   data:
     - template_name: C8000V_EDGE
-      device_type: C8000V
+      device_type: [Cisco, C8000V]
       role: edge
       status: active
       cpu: 2
@@ -24,7 +24,7 @@ spec:
           - edges
 
     - template_name: CloudGuard_EDGE
-      device_type: CloudGuard
+      device_type: [Check Point, CloudGuard]
       role: edge_firewall
       status: active
       cpu: 2

--- a/tests/integration/data/bootstrap/10_physical_device_templates.yml
+++ b/tests/integration/data/bootstrap/10_physical_device_templates.yml
@@ -5,7 +5,7 @@ spec:
   kind: TemplateDcimDevice
   data:
     - template_name: N9K-C9336C-FX2_SPINE
-      device_type: N9K-C9336C-FX2
+      device_type: [Cisco, N9K-C9336C-FX2]
       role: spine
       member_of_groups:
         - spines
@@ -23,7 +23,7 @@ spec:
             name: mgmt0
             role: management
     - template_name: N9K-C9336C-FX2_LEAF
-      device_type: N9K-C9336C-FX2
+      device_type: [Cisco, N9K-C9336C-FX2]
       role: leaf
       member_of_groups:
         - leafs
@@ -41,7 +41,7 @@ spec:
             name: mgmt0
             role: management
     - template_name: N9K-C9316D-GX_SPINE
-      device_type: N9K-C9316D-GX
+      device_type: [Cisco, N9K-C9316D-GX]
       role: spine
       member_of_groups:
         - spines
@@ -59,7 +59,7 @@ spec:
             name: mgmt0
             role: management
     - template_name: N9K-C9316D-GX_LEAF
-      device_type: N9K-C9316D-GX
+      device_type: [Cisco, N9K-C9316D-GX]
       role: leaf
       member_of_groups:
         - leafs
@@ -77,7 +77,7 @@ spec:
             name: mgmt0
             role: management
     - template_name: DCS-7280DR3-24-F_SPINE
-      device_type: DCS-7280DR3-24-F
+      device_type: [Arista, DCS-7280DR3-24-F]
       role: spine
       member_of_groups:
         - spines
@@ -95,7 +95,7 @@ spec:
             name: Management1
             role: management
     - template_name: CCS-720DP-48S-2F_LEAF
-      device_type: CCS-720DP-48S-2F
+      device_type: [Arista, CCS-720DP-48S-2F]
       role: leaf
       member_of_groups:
         - leafs
@@ -113,7 +113,7 @@ spec:
             name: Management1
             role: management
     - template_name: SRX-1500_EDGE_FIREWALL
-      device_type: SRX-1500
+      device_type: [F5 Networks, NGINX]
       role: edge_firewall
       member_of_groups:
         - firewalls
@@ -128,7 +128,7 @@ spec:
             name: ge-0/0/[0-3]
             role: leaf
     - template_name: SRX-1500_DC_FIREWALL
-      device_type: SRX-1500
+      device_type: [F5 Networks, NGINX]
       role: dc_firewall
       member_of_groups:
         - firewalls
@@ -143,7 +143,7 @@ spec:
             name: ge-0/0/[0-3]
             role: leaf
     - template_name: C9200L-24P-4G_OOB
-      device_type: C9200L-24P-4G
+      device_type: [Cisco, C9200L-24P-4G]
       role: oob
       member_of_groups:
         - oobs
@@ -158,7 +158,7 @@ spec:
             name: mgmt0
             role: management
     - template_name: SCG50R_CONSOLE
-      device_type: SCG50R
+      device_type: [Perle, SCG50R]
       role: console
       member_of_groups:
         - consoles
@@ -170,7 +170,7 @@ spec:
             name: Ethernet[0-1]
             role: management
     - template_name: N9K-C9316D-GX_EDGE
-      device_type: N9K-C9316D-GX
+      device_type: [Cisco, N9K-C9316D-GX]
       role: edge
       member_of_groups:
         - edges
@@ -188,7 +188,7 @@ spec:
             name: mgmt0
             role: management
     - template_name: 5912-54X-O-AC-F_LEAF
-      device_type: 5912-54X-O-AC-F
+      device_type: [Edgecore, 5912-54X-O-AC-F]
       role: leaf
       member_of_groups:
         - leafs
@@ -209,7 +209,7 @@ spec:
             name: eth0
             role: management
     - template_name: 7726-32X-O_SPINE
-      device_type: 7726-32X-O
+      device_type: [Edgecore, 7726-32X-O]
       role: spine
       member_of_groups:
         - spines

--- a/tests/integration/data/bootstrap/11_device_templates_console.yml
+++ b/tests/integration/data/bootstrap/11_device_templates_console.yml
@@ -5,7 +5,7 @@ spec:
   kind: TemplateDcimDevice
   data:
     - template_name: N9K-C9336C-FX2_SPINE
-      device_type: N9K-C9336C-FX2
+      device_type: [Cisco, N9K-C9336C-FX2]
       role: spine
       status: active
       interfaces:
@@ -15,7 +15,7 @@ spec:
             name: con
             role: console
     - template_name: N9K-C9336C-FX2_LEAF
-      device_type: N9K-C9336C-FX2
+      device_type: [Cisco, N9K-C9336C-FX2]
       role: leaf
       status: active
       interfaces:
@@ -25,7 +25,7 @@ spec:
             name: con
             role: console
     - template_name: N9K-C9316D-GX_SPINE
-      device_type: N9K-C9316D-GX
+      device_type: [Cisco, N9K-C9316D-GX]
       role: spine
       status: active
       interfaces:
@@ -35,7 +35,7 @@ spec:
             name: con
             role: console
     - template_name: N9K-C9316D-GX_LEAF
-      device_type: N9K-C9316D-GX
+      device_type: [Cisco, N9K-C9316D-GX]
       role: leaf
       status: active
       interfaces:
@@ -45,7 +45,7 @@ spec:
             name: con
             role: console
     - template_name: DCS-7280DR3-24-F_SPINE
-      device_type: DCS-7280DR3-24-F
+      device_type: [Arista, DCS-7280DR3-24-F]
       role: spine
       status: active
       interfaces:
@@ -55,7 +55,7 @@ spec:
             name: Console
             role: console
     - template_name: CCS-720DP-48S-2F_LEAF
-      device_type: CCS-720DP-48S-2F
+      device_type: [Arista, CCS-720DP-48S-2F]
       role: leaf
       status: active
       interfaces:
@@ -65,7 +65,7 @@ spec:
             name: Console
             role: console
     - template_name: SRX-1500_EDGE_FIREWALL
-      device_type: SRX-1500
+      device_type: [F5 Networks, NGINX]
       role: edge_firewall
       status: active
       interfaces:
@@ -75,7 +75,7 @@ spec:
             name: con
             role: console
     - template_name: C9200L-24P-4G_OOB
-      device_type: C9200L-24P-4G
+      device_type: [Cisco, C9200L-24P-4G]
       role: oob
       status: active
       interfaces:
@@ -85,7 +85,7 @@ spec:
             name: con
             role: console
     - template_name: SCG50R_CONSOLE
-      device_type: SCG50R
+      device_type: [Perle, SCG50R]
       role: console
       status: active
       interfaces:
@@ -95,7 +95,7 @@ spec:
             name: con[0-24]
             role: console
     - template_name: N9K-C9316D-GX_EDGE
-      device_type: N9K-C9316D-GX
+      device_type: [Cisco, N9K-C9316D-GX]
       role: edge
       status: active
       interfaces:

--- a/tests/integration/data/bootstrap/14_design_elements.yml
+++ b/tests/integration/data/bootstrap/14_design_elements.yml
@@ -8,95 +8,95 @@ spec:
       description: 2 Cisco C9336C-FX2 spines
       quantity: 2
       role: spine
-      device_type: N9K-C9336C-FX2
+      device_type: [Cisco, N9K-C9336C-FX2]
       template: N9K-C9336C-FX2_SPINE
     - name: 8 CISCO LEAFS N9K-C9336C-FX2
       description: 8 Cisco C9336C-FX2 leafs
       quantity: 8
       role: leaf
-      device_type: N9K-C9336C-FX2
+      device_type: [Cisco, N9K-C9336C-FX2]
       template: N9K-C9336C-FX2_LEAF
     - name: 4 CISCO SPINES N9K-C9316D-GX
       description: 4 Cisco N9K-C9316D-GX spines
       quantity: 4
       role: spine
-      device_type: N9K-C9316D-GX
+      device_type: [Cisco, N9K-C9316D-GX]
       template: N9K-C9316D-GX_SPINE
     - name: 16 CISCO LEAFS N9K-C9316D-GX
       description: 16 Cisco N9K-C9316D-GX leafs
       quantity: 16
       role: leaf
-      device_type: N9K-C9316D-GX
+      device_type: [Cisco, N9K-C9316D-GX]
       template: N9K-C9316D-GX_LEAF
     - name: 2 ARISTA SPINES DCS-7280DR3-24-F
       description: 2 Arista DCS-7280DR3-24-F spines
       quantity: 2
       role: spine
-      device_type: DCS-7280DR3-24-F
+      device_type: [Arista, DCS-7280DR3-24-F]
       template: DCS-7280DR3-24-F_SPINE
     - name: 4 ARISTA LEAFS CCS-720DP-48S-2F
       description: 4 Arista CCS-720DP-48S-2F leafs
       quantity: 4
       role: leaf
-      device_type: CCS-720DP-48S-2F
+      device_type: [Arista, CCS-720DP-48S-2F]
       template: CCS-720DP-48S-2F_LEAF
     - name: 6 ARISTA LEAFS CCS-720DP-48S-2F
       description: 6 Arista CCS-720DP-48S-2F leafs
       quantity: 6
       role: leaf
-      device_type: CCS-720DP-48S-2F
+      device_type: [Arista, CCS-720DP-48S-2F]
       template: CCS-720DP-48S-2F_LEAF
     - name: 2 JUNIPER EDGE FIREWALLS SRX-1500
       description: 2 Juniper EDGE SRX-1500 firewalls
       quantity: 2
       role: edge_firewall
-      device_type: SRX-1500
+      device_type: [F5 Networks, NGINX]
       template: SRX-1500_EDGE_FIREWALL
     - name: 2 JUNIPER DC FIREWALLS SRX-1500
       description: 2 Juniper DC SRX-1500 firewalls
       quantity: 2
       role: dc_firewall
-      device_type: SRX-1500
+      device_type: [F5 Networks, NGINX]
       template: SRX-1500_DC_FIREWALL
     - name: 2 CISCO OOB SWITCHES C9200L-24P-4G
       description: 2 Cisco C9200L-24P-4G OOB switches
       quantity: 2
       role: oob
-      device_type: C9200L-24P-4G
+      device_type: [Cisco, C9200L-24P-4G]
       template: C9200L-24P-4G_OOB
     - name: 2 PERLE CONSOLE SCG50R
       description: 2 Perle SCG50R console servers
       quantity: 2
       role: console
-      device_type: SCG50R
+      device_type: [Perle, SCG50R]
       template: SCG50R_CONSOLE
     - name: 2 CISCO EDGE N9K-C9316D-GX
       description: 2 Cisco N9K-C9316D-GX edges
       quantity: 2
       role: edge
-      device_type: N9K-C9316D-GX
+      device_type: [Cisco, N9K-C9316D-GX]
       template: N9K-C9316D-GX_EDGE
     - name: 2 EDGECORE SPINES 7726-32X-O
       description: 2 EDGECORE 7726-32X-O spines
       quantity: 2
       role: spine
-      device_type: 7726-32X-O
+      device_type: [Edgecore, 7726-32X-O]
       template: 7726-32X-O_SPINE
     - name: 4 EDGECORE LEAFS 5912-54X-O-AC-F
       description: 4 EDGECORE 5912-54X-O-AC-F leafs
       quantity: 4
       role: leaf
-      device_type: 5912-54X-O-AC-F
+      device_type: [Edgecore, 5912-54X-O-AC-F]
       template: 5912-54X-O-AC-F_LEAF
     - name: 2 C8000V EDGES
       description: 2 C8000V edges
       quantity: 2
       role: edge
-      device_type: C8000V
+      device_type: [Cisco, C8000V]
       template: C8000V_EDGE
     - name: 2 CloudGuard Security Edges
       description: 2 CloudGuard Security Edges
       quantity: 2
       role: edge_firewall
-      device_type: CloudGuard
+      device_type: [Check Point, CloudGuard]
       template: CloudGuard_EDGE

--- a/tests/integration/data/lb/00_device_type.yml
+++ b/tests/integration/data/lb/00_device_type.yml
@@ -2,7 +2,7 @@
 apiVersion: infrahub.app/v1
 kind: Object
 spec:
-  kind: DcimDeviceType
+  kind: DcimVirtualDeviceType
   data:
     - name: HA-PROXY
       part_number: HA-PROXY

--- a/tests/integration/data/lb/01_lb_templates.yml
+++ b/tests/integration/data/lb/01_lb_templates.yml
@@ -5,7 +5,7 @@ spec:
   kind: TemplateDcimVirtualDevice
   data:
     - template_name: HA-PROXY
-      device_type: HA-PROXY
+      device_type: [HAProxy Technologies, HA-PROXY]
       platform: Linux
       role: load_balancer
       status: active
@@ -20,7 +20,7 @@ spec:
         member_of_groups:
           - loadbalancers
     - template_name: NGINX
-      device_type: NGINX
+      device_type: [F5 Networks, NGINX]
       platform: Linux
       role: load_balancer
       status: active

--- a/tests/integration/data/lb/02_lb_devices.yml
+++ b/tests/integration/data/lb/02_lb_devices.yml
@@ -11,7 +11,7 @@ spec:
           name: DC-1
           shortname: DC-1
           parent: Katowice
-      device_type: HA-PROXY
+      device_type: [HAProxy Technologies, HA-PROXY]
       role: load_balancer
       status: active
       cpu: 2
@@ -65,7 +65,7 @@ spec:
           name: DC-1
           shortname: DC-1
           parent: Katowice
-      device_type: NGINX
+      device_type: [F5 Networks, NGINX]
       role: load_balancer
       status: active
       cpu: 2

--- a/tests/unit/test_cloud_security_mock.py
+++ b/tests/unit/test_cloud_security_mock.py
@@ -111,7 +111,7 @@ spec:
 apiVersion: infrahub.app/v1
 kind: Object
 spec:
-  kind: DcimDeviceType
+  kind: DcimVirtualDeviceType
   data:
     - name: ZIA-Gateway
       manufacturer: Zscaler

--- a/tests/unit/test_cloud_security_mock.py
+++ b/tests/unit/test_cloud_security_mock.py
@@ -165,7 +165,7 @@ spec:
   kind: DcimVirtualDevice
   data:
     - name: zscaler-zia-gateway-01
-      device_type: ZIA-Gateway
+      device_type: [Zscaler, ZIA-Gateway]
       description: Production Zscaler gateway
     - name: zscaler-zpa-connector-01
       device_type: ZPA-Connector


### PR DESCRIPTION
We can wind back commit 3 if it is deemed unneeded, but I think given the model is a combination of the name and manufacturer, I figured the HFID update made sense; especially where I have seen duplicate models between manufacturers.

## Commit 1

Addresses #23 by introducing:

- DcimGenericDeviceType
- DcimPhysicalDeviceType
- DcimVirtualDeviceType


It updates the referenced schemas, objects, and tests accordingly.

## Commit 2

Adds demo data to show/test the new model updates.

## Commit 3

Update `device_type` hfid field to use both `manufacturer` and `name`