### PR TITLE
Make it possible to namespace this docker environment from others

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,28 @@ export INFRAHUB_ENTERPRISE=false
 export INFRAHUB_GIT_LOCAL=false
 
 # =============================================================================
+# Parallel Instance Configuration
+# =============================================================================
+# Use these settings to run multiple instances of this project simultaneously.
+# Each instance needs a unique project name and different ports.
+#
+# Example for a second instance:
+#   INFRAHUB_PROJECT_NAME=infrahub-2
+#   INFRAHUB_PORT=8100
+#   PREFECT_PORT=4201
+#   STREAMLIT_PORT=8502
+#   INFRAHUB_ADDRESS=http://localhost:8100
+#   INFRAHUB_UI_URL=http://localhost:8100
+
+# Docker Compose project name (defaults to directory name)
+# export INFRAHUB_PROJECT_NAME=infrahub-bundle-dc
+
+# Port mappings for Docker services
+# export INFRAHUB_PORT=8000
+# export PREFECT_PORT=4200
+# export STREAMLIT_PORT=8501
+
+# =============================================================================
 # Service Catalog Configuration
 # =============================================================================
 
@@ -61,10 +83,6 @@ export API_TIMEOUT=30
 # Number of retry attempts for failed API requests
 # The service catalog will retry failed requests this many times before giving up
 export API_RETRY_COUNT=3
-
-# Streamlit server port (optional)
-# Port on which the Streamlit application will run
-# STREAMLIT_PORT=8501
 
 # =============================================================================
 # Additional Notes

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,4 +1,10 @@
 ---
+# Override file for bundle-dc project
+# Port configuration via environment variables for running multiple instances:
+#   INFRAHUB_PORT (default: 8000) - Infrahub server
+#   PREFECT_PORT (default: 4200) - Prefect task manager UI
+#   STREAMLIT_PORT (default: 8501) - Service catalog UI
+
 services:
   database:
     environment:
@@ -9,10 +15,15 @@ services:
       - NEO4J_dbms_memory_heap_max__size=4g
       - NEO4J_dbms_memory_pagecache_size=2g
 
+  # Override Infrahub server port for parallel instances
+  infrahub-server:
+    ports:
+      - "${INFRAHUB_PORT:-8000}:8000"
+
   # Expose prefect UI
   task-manager:
     ports:
-      - "4200:4200"
+      - "${PREFECT_PORT:-4200}:4200"
 
   # Mount local repository for local development
   # Used when INFRAHUB_GIT_LOCAL=true to work with local generator/transform changes
@@ -26,10 +37,10 @@ services:
       dockerfile: Dockerfile
     container_name: service-catalog
     ports:
-      - "8501:8501"
+      - "${STREAMLIT_PORT:-8501}:8501"
     environment:
       - INFRAHUB_ADDRESS=http://infrahub-server:8000
-      - INFRAHUB_UI_URL=http://localhost:8000
+      - INFRAHUB_UI_URL=${INFRAHUB_UI_URL:-http://localhost:8000}
       - INFRAHUB_API_TOKEN=${INFRAHUB_API_TOKEN:-06438eb2-8019-4776-878c-0941b1f1d1ec}
       - DEFAULT_BRANCH=main
       - GENERATOR_WAIT_TIME=60

--- a/tasks.py
+++ b/tasks.py
@@ -26,31 +26,42 @@ INFRAHUB_ENTERPRISE = os.getenv("INFRAHUB_ENTERPRISE", "false").lower() == "true
 INFRAHUB_SERVICE_CATALOG = os.getenv("INFRAHUB_SERVICE_CATALOG", "false").lower() == "true"
 INFRAHUB_GIT_LOCAL = os.getenv("INFRAHUB_GIT_LOCAL", "false").lower() == "true"
 MAIN_DIRECTORY_PATH = Path(__file__).parent
+INFRAHUB_PROJECT_NAME = os.getenv("INFRAHUB_PROJECT_NAME", MAIN_DIRECTORY_PATH.name)
 
 
 # Download compose file and use with override
 def get_compose_command() -> str:
-    """Generate docker compose command with override support."""
+    """Generate docker compose command with override support.
+
+    Supports layered compose files:
+    1. docker-compose.yml (base, downloaded or local)
+    2. docker-compose.override.yml (committed overrides, uses env vars for ports)
+
+    The project name is controlled by INFRAHUB_PROJECT_NAME env var,
+    defaulting to the directory name.
+    """
     local_compose_file = MAIN_DIRECTORY_PATH / "docker-compose.yml"
     override_file = MAIN_DIRECTORY_PATH / "docker-compose.override.yml"
 
-    # Check if local docker-compose.yml exists
+    base_cmd = f"docker compose -p {INFRAHUB_PROJECT_NAME}"
+
+    # If we have a local docker-compose.yml, use it directly
     if local_compose_file.exists():
-        # Use local docker-compose.yml file
+        cmd = f"{base_cmd} -f {local_compose_file}"
         if override_file.exists():
-            return f"docker compose -p infrahub -f {local_compose_file} -f {override_file}"
-        return f"docker compose -p infrahub-bundle-dc -f {local_compose_file}"
+            cmd += f" -f {override_file}"
+        return cmd
 
     # Fall back to downloading from infrahub.opsmill.io
-    # Determine the base URL based on edition
     if INFRAHUB_ENTERPRISE:
         base_url = f"https://infrahub.opsmill.io/enterprise/{INFRAHUB_VERSION}"
     else:
         base_url = f"https://infrahub.opsmill.io/{INFRAHUB_VERSION}"
 
+    cmd = f"curl -s {base_url} | {base_cmd} -f -"
     if override_file.exists():
-        return f"curl -s {base_url} | docker compose -p infrahub -f - -f {override_file}"
-    return f"curl -s {base_url} | docker compose -p infrahub -f -"
+        cmd += f" -f {override_file}"
+    return cmd
 
 
 def get_compose_source() -> str:
@@ -119,6 +130,7 @@ def info(context: Context) -> None:
     info_msg = (
         f"[cyan]Edition:[/cyan] {edition}\n"
         f"[cyan]Version:[/cyan] {INFRAHUB_VERSION}\n"
+        f"[cyan]Project Name:[/cyan] {INFRAHUB_PROJECT_NAME}\n"
         f"[cyan]Compose Source:[/cyan] {COMPOSE_SOURCE}\n"
         f"[cyan]Service Catalog:[/cyan] {'Enabled' if INFRAHUB_SERVICE_CATALOG else 'Disabled'}\n"
         f"[cyan]Local Git Repository:[/cyan] {'Enabled' if INFRAHUB_GIT_LOCAL else 'Disabled'}\n"


### PR DESCRIPTION
The end goal of these changes is to provide a user with the ability to have multiple separate instances of infrahub running locally at the same time for development and troubleshooting purposes. This is done via docker compose project namespacing and utilizing a docker-compose.local.yml file for to easily modify the ports infrahub is operating on.