### PR TITLE
fix: remove blank line between list items in docs/AGENTS.md

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -39,7 +39,6 @@ npm run typecheck
   - **How-to guides** (task-oriented)
   - **Explanation** (understanding-oriented)
   - **Reference** (information-oriented)
-
 - Use sentence case for headings (lowercase except first word and proper nouns)
 - Specify language in fenced code blocks
 - Surround lists and code blocks with blank lines


### PR DESCRIPTION
## Summary
- Fixes markdown-lint CI failure caused by an unexpected blank line between list items in `docs/AGENTS.md` line 42
- Resolves [failed run](https://github.com/opsmill/infrahub-bundle-dc/actions/runs/23063277470)

## Test plan
- [x] `uv run invoke lint` passes locally
- [ ] CI markdown-lint job passes