### PR TITLE
chore: rename project from infrahub-bundle-dc to infrahub-demo-dc

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,7 +51,7 @@ export INFRAHUB_GIT_LOCAL=false
 #   INFRAHUB_UI_URL=http://localhost:8100
 
 # Docker Compose project name (defaults to directory name)
-# export INFRAHUB_PROJECT_NAME=infrahub-bundle-dc
+# export INFRAHUB_PROJECT_NAME=infrahub-demo-dc
 
 # Port mappings for Docker services
 # export INFRAHUB_PORT=8000

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -34,4 +34,4 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add .
-          if ! (git diff --quiet && git diff --staged --quiet); then git commit -m "Sync docs from infrahub-bundle-dc repo" && git push; fi
+          if ! (git diff --quiet && git diff --staged --quiet); then git commit -m "Sync docs from infrahub-demo-dc repo" && git push; fi

--- a/docs/docs/developer-guide.mdx
+++ b/docs/docs/developer-guide.mdx
@@ -27,7 +27,7 @@ All components are registered in `.infrahub.yml`, which acts as the configuratio
 ## Project structure
 
 ```text
-infrahub-bundle-dc/
+infrahub-demo-dc/
 ├── .infrahub.yml              # Component registration
 ├── checks/                    # Validation checks
 │   ├── spine.py
@@ -777,8 +777,8 @@ uv run invoke validate
 
 ```bash
 # Clone repository
-git clone https://github.com/opsmill/infrahub-bundle-dc.git
-cd infrahub-bundle-dc
+git clone https://github.com/opsmill/infrahub-demo-dc.git
+cd infrahub-demo-dc
 
 # Install dependencies
 uv sync
@@ -869,7 +869,7 @@ Use the `--rebuild` flag when you modify:
 5. Check logs for errors:
 
 ```bash
-docker logs infrahub-bundle-dc-service-catalog-1
+docker logs infrahub-demo-dc-service-catalog-1
 ```
 
 #### Service catalog environment variables

--- a/docs/docs/install.mdx
+++ b/docs/docs/install.mdx
@@ -48,8 +48,8 @@ uv --version
 Clone the demo repository to your local machine:
 
 ```bash
-git clone https://github.com/opsmill/infrahub-bundle-dc.git
-cd infrahub-bundle-dc
+git clone https://github.com/opsmill/infrahub-demo-dc.git
+cd infrahub-demo-dc
 ```
 
 ## Step 3: install Python dependencies
@@ -293,7 +293,7 @@ uv run infrahubctl object load objects/security/
 uv run python scripts/populate_security_relationships.py
 
 # 6. Add the demo repository
-uv run infrahubctl repository add DEMO https://github.com/opsmill/infrahub-bundle-dc.git --read-only --ref main
+uv run infrahubctl repository add DEMO https://github.com/opsmill/infrahub-demo-dc.git --read-only --ref main
 
 # 7. Load event actions (optional, enables automatic generator execution)
 uv run infrahubctl object load objects/events/

--- a/docs/docs/readme.mdx
+++ b/docs/docs/readme.mdx
@@ -108,7 +108,7 @@ Templates transform Infrahub data into deployable artifacts including device con
 
 ## Community and support
 
-- **Source code**: [GitHub repository](https://github.com/opsmill/infrahub-bundle-dc)
+- **Source code**: [GitHub repository](https://github.com/opsmill/infrahub-demo-dc)
 - **Infrahub documentation**: [docs.infrahub.app](https://docs.infrahub.app)
 - **Discord community**: [Discord](https://discord.gg/opsmill)
 - **OpsMill website**: [opsmill.com](https://opsmill.com)

--- a/docs/docs/security-management.mdx
+++ b/docs/docs/security-management.mdx
@@ -510,4 +510,4 @@ For deeper understanding:
 
 - **[Understanding the concepts](./concepts.mdx)** - Learn about schema-driven data modeling
 - **[Developer guide](./developer-guide.mdx)** - Understand how transformations and templates work
-- **[Infrahub security schema](https://github.com/opsmill/infrahub-bundle-dc/blob/main/schemas/extensions/security/security.yml)** - Review the complete schema definition
+- **[Infrahub security schema](https://github.com/opsmill/infrahub-demo-dc/blob/main/schemas/extensions/security/security.yml)** - Review the complete schema definition

--- a/docs/docs/service-catalog.mdx
+++ b/docs/docs/service-catalog.mdx
@@ -74,7 +74,7 @@ Check that the service-catalog container is running:
 docker ps --filter "name=service-catalog"
 ```
 
-You should see a container named `infrahub-bundle-dc-service-catalog-1` or similar in the output.
+You should see a container named `infrahub-demo-dc-service-catalog-1` or similar in the output.
 
 ## Step 2: access the service catalog
 
@@ -92,7 +92,7 @@ The interface displays:
 - **Create new data center** - Button to access the DC creation form
 
 :::info
-If the page doesn't load, verify the container is running and check the logs with `docker logs infrahub-bundle-dc-service-catalog-1`.
+If the page doesn't load, verify the container is running and check the logs with `docker logs infrahub-demo-dc-service-catalog-1`.
 :::
 
 ## Step 3: switch branches and view infrastructure
@@ -386,7 +386,7 @@ If the container fails to start:
 1. Check Docker logs:
 
 ```bash
-docker logs infrahub-bundle-dc-service-catalog-1
+docker logs infrahub-demo-dc-service-catalog-1
 ```
 
 2. Verify environment variables in `.env`:
@@ -416,7 +416,7 @@ docker ps --format "table {{.Names}}\t{{.Ports}}" --filter "name=service-catalog
 3. Try accessing via container IP directly:
 
 ```bash
-docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' infrahub-bundle-dc-service-catalog-1
+docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' infrahub-demo-dc-service-catalog-1
 ```
 
 ### Branch selector is empty
@@ -426,7 +426,7 @@ If no branches appear in the dropdown:
 1. Verify Infrahub server connection from the container:
 
 ```bash
-docker exec infrahub-bundle-dc-service-catalog-1 curl http://infrahub-server:8000/api/schema
+docker exec infrahub-demo-dc-service-catalog-1 curl http://infrahub-server:8000/api/schema
 ```
 
 2. Check that branches exist in Infrahub:
@@ -438,7 +438,7 @@ uv run infrahubctl branch list
 3. Review Service Catalog logs for API errors:
 
 ```bash
-docker logs infrahub-bundle-dc-service-catalog-1 | grep -i error
+docker logs infrahub-demo-dc-service-catalog-1 | grep -i error
 ```
 
 ### Generator timeout errors
@@ -464,7 +464,7 @@ If the submit button doesn't work:
 4. Review Service Catalog logs during submission:
 
 ```bash
-docker logs -f infrahub-bundle-dc-service-catalog-1
+docker logs -f infrahub-demo-dc-service-catalog-1
 ```
 
 ## Advanced usage

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -14,7 +14,7 @@ const config: Config = {
   baseUrl: '/',
 
   organizationName: 'opsmill',
-  projectName: 'infrahub-bundle-dc',
+  projectName: 'infrahub-demo-dc',
 
   onBrokenLinks: 'throw',
   onDuplicateRoutes: "throw",
@@ -40,7 +40,7 @@ const config: Config = {
         docs: {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
-          editUrl: "https://github.com/opsmill/infrahub-bundle-dc/tree/main/docs",
+          editUrl: "https://github.com/opsmill/infrahub-demo-dc/tree/main/docs",
           routeBasePath: "/",
           sidebarCollapsed: true,
           sidebarPath: "./sidebars.ts",
@@ -76,7 +76,7 @@ const config: Config = {
         //   position: "right",
         // },
         {
-          href: "https://github.com/opsmill/infrahub-bundle-dc",
+          href: "https://github.com/opsmill/infrahub-demo-dc",
           position: "right",
           className: "header-github-link",
           "aria-label": "GitHub repository",

--- a/objects/git-repo/github.yml
+++ b/objects/git-repo/github.yml
@@ -5,5 +5,5 @@ spec:
   kind: CoreReadOnlyRepository
   data:
     - name: bundle-dc
-      location: "https://github.com/opsmill/infrahub-bundle-dc.git"
+      location: "https://github.com/opsmill/infrahub-demo-dc.git"
       ref: "main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=45", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "infrahub-bundle-dc"
+name = "infrahub-demo-dc"
 version = "1.0.1"
 description = "Design driven automation with Infrahub"
 readme = "README.md"

--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -469,7 +469,7 @@ def main(branch: str = "main") -> int:
         console.print("[dim]Using local repository: /upstream[/dim]")
     else:
         repo_file = "objects/git-repo/github.yml"
-        console.print("[dim]Using GitHub repository: https://github.com/opsmill/infrahub-bundle-dc.git[/dim]")
+        console.print("[dim]Using GitHub repository: https://github.com/opsmill/infrahub-demo-dc.git[/dim]")
 
     # Execute repository addition command
     # capture_output=True prevents streaming to terminal (we handle output manually)

--- a/tasks.py
+++ b/tasks.py
@@ -1,4 +1,4 @@
-"""Tasks for the infrahub-bundle-dc project."""
+"""Tasks for the infrahub-demo-dc project."""
 
 import os
 import sys

--- a/uv.lock
+++ b/uv.lock
@@ -488,7 +488,7 @@ wheels = [
 ]
 
 [[package]]
-name = "infrahub-bundle-dc"
+name = "infrahub-demo-dc"
 version = "1.0.1"
 source = { editable = "." }
 dependencies = [


### PR DESCRIPTION
## Summary

- Rename all references from `infrahub-bundle-dc` to `infrahub-demo-dc` across the entire project
- Updates docs, GitHub workflows, Docusaurus config, pyproject.toml, bootstrap script, tasks, git-repo object, and uv.lock

## Test plan

- [ ] Verify `uv sync` succeeds with the renamed project
- [ ] Verify docs build correctly with `cd docs && npm run build`
- [ ] Verify `uv run invoke bootstrap` uses the correct repo URL
- [ ] Confirm GitHub workflow references the new repo name

🤖 Generated with [Claude Code](https://claude.com/claude-code)