### PR TITLE
Align base schemas with schema-library and make upsert idempotent

### DIFF
--- a/objects/bootstrap/18_devices.yml
+++ b/objects/bootstrap/18_devices.yml
@@ -8,7 +8,7 @@ spec:
       role: edge_firewall
       device_type: [Juniper, SRX-1500]
       platform: [Juniper, JunOS]
-      location: PAR-1
+      location: par-1
       status: active
       member_of_groups:
         - juniper_firewall
@@ -41,7 +41,7 @@ spec:
       role: leaf
       device_type: [Cisco, N9K-C93108TC-FX]
       platform: [Cisco, NX-OS]
-      location: LON-1
+      location: lon-1
       status: active
       member_of_groups:
         - leafs
@@ -61,7 +61,7 @@ spec:
       role: spine
       device_type: [Juniper, QFX5220-32CD]
       platform: [Juniper, JunOS]
-      location: FRA-1
+      location: fra-1
       status: active
       member_of_groups:
         - spines
@@ -81,7 +81,7 @@ spec:
       role: spine
       device_type: [Arista, DCS-7280DR3-24-F]
       platform: [Arista, EOS]
-      location: BCN-1
+      location: bcn-1
       status: active
       member_of_groups:
         - spines
@@ -101,7 +101,7 @@ spec:
       role: leaf
       device_type: [Edgecore, 5912-54X-O-AC-F]
       platform: [Generic, Sonic OS]
-      location: CHI-1
+      location: chi-1
       status: active
       member_of_groups:
         - leafs

--- a/objects/cloud_security/02_zscaler_devices.yml
+++ b/objects/cloud_security/02_zscaler_devices.yml
@@ -22,7 +22,7 @@ spec:
         data:
           name: DC-1
           shortname: DC-1
-          parent: Katowice
+          parent: ktw
       device_type: [Zscaler, ZIA-Gateway]
       role: edge_firewall
       status: active
@@ -45,7 +45,7 @@ spec:
         data:
           name: DC-1
           shortname: DC-1
-          parent: Katowice
+          parent: ktw
       device_type: [Zscaler, ZIA-Gateway]
       role: edge_firewall
       status: active
@@ -68,7 +68,7 @@ spec:
         data:
           name: DC-1
           shortname: DC-1
-          parent: Katowice
+          parent: ktw
       device_type: [Zscaler, ZIA-Gateway]
       role: edge_firewall
       status: active

--- a/objects/dc/dc-arista-s.yml
+++ b/objects/dc/dc-arista-s.yml
@@ -5,7 +5,7 @@ spec:
   kind: TopologyDataCenter
   data:
     - name: dc-arista
-      location: Frankfurt
+      location: fra
       description: Arista Data Center with cEOS switches
       strategy: ospf-ibgp
       design: PHYSICAL DC ARISTA S

--- a/objects/dc/dc-cisco-s-border-leafs.yml
+++ b/objects/dc/dc-cisco-s-border-leafs.yml
@@ -5,7 +5,7 @@ spec:
   kind: TopologyDataCenter
   data:
     - name: dc-cisco-border
-      location: Katowice
+      location: ktw
       description: Cisco Data Center with border leafs
       strategy: ospf-ibgp
       design: PHYSICAL DC CISCO S WITH BORDER LEAFS

--- a/objects/dc/dc-cisco-s.yml
+++ b/objects/dc/dc-cisco-s.yml
@@ -5,7 +5,7 @@ spec:
   kind: TopologyDataCenter
   data:
     - name: dc-cisco
-      location: Munich
+      location: muc
       description: Cisco Data Center with Nexus switches
       strategy: ebgp-ibgp
       design: PHYSICAL DC CISCO S

--- a/objects/dc/dc-juniper-s.yml
+++ b/objects/dc/dc-juniper-s.yml
@@ -5,7 +5,7 @@ spec:
   kind: TopologyDataCenter
   data:
     - name: dc-juniper
-      location: London
+      location: lon
       description: Juniper Data Center with Juniper QFX5220-32CD
       strategy: ospf-ibgp
       design: PHYSICAL DC JUNIPER S

--- a/objects/dc/dc-sonic-border-leafs.yml
+++ b/objects/dc/dc-sonic-border-leafs.yml
@@ -5,7 +5,7 @@ spec:
   kind: TopologyDataCenter
   data:
     - name: dc-sonic
-      location: Barcelona
+      location: bcn
       description: SONiC Data Center with border leafs
       strategy: ebgp-ibgp
       design: PHYSICAL DC SONIC S WITH BORDER LEAFS

--- a/objects/lb/02_lb_devices.yml
+++ b/objects/lb/02_lb_devices.yml
@@ -10,7 +10,7 @@ spec:
         data:
           name: DC-1
           shortname: DC-1
-          parent: Katowice
+          parent: ktw
       device_type: [HAProxy Technologies, HA-PROXY]
       object_template: HA-PROXY
       status: active
@@ -66,7 +66,7 @@ spec:
         data:
           name: DC-1
           shortname: DC-1
-          parent: Katowice
+          parent: ktw
       object_template: NGINX
       topology: DC-1
       status: active

--- a/objects/pop/pop-1.yml
+++ b/objects/pop/pop-1.yml
@@ -5,7 +5,7 @@ spec:
   kind: TopologyColocationCenter
   data:
     - name: POP-1
-      location: London
+      location: lon
       description: London Virtual POP
       design: VIRTUAL POP S
       emulation: true

--- a/objects/pop/pop-2.yml
+++ b/objects/pop/pop-2.yml
@@ -5,7 +5,7 @@ spec:
   kind: TopologyColocationCenter
   data:
     - name: POP-2
-      location: Chicago
+      location: chi
       description: Chicago Physical POP
       design: PHYSICAL POP S
       emulation: true

--- a/schemas/base/dcim.yml
+++ b/schemas/base/dcim.yml
@@ -12,7 +12,7 @@ generics:
       - name__value
     order_by:
       - name__value
-    display_label: "{{ name__value }}"
+    display_label: name__value
     attributes:
       - name: name
         kind: Text
@@ -22,27 +22,6 @@ generics:
         kind: Text
         optional: true
         order_weight: 2000
-      - name: status
-        kind: Dropdown
-        optional: false
-        order_weight: 1100
-        choices:
-          - name: active
-            label: Active
-            description: Fully operational and currently in service.
-            color: "#7fbf7f"
-          - name: provisioning
-            label: Provisioning
-            description: In the process of being set up and configured.
-            color: "#ffff7f"
-          - name: maintenance
-            label: Maintenance
-            description: Undergoing routine maintenance or repairs.
-            color: "#ffd27f"
-          - name: drained
-            label: Drained
-            description: Temporarily taken out of service.
-            color: "#bfbfbf"
       - name: os_version
         kind: Text
         optional: true
@@ -117,7 +96,6 @@ generics:
         cardinality: one
         kind: Attribute
         order_weight: 1500
-        identifier: hosting__devices
 
   - name: Endpoint
     namespace: Dcim
@@ -139,6 +117,7 @@ generics:
       - name: connected_endpoints
         peer: DcimEndpoint
         cardinality: many
+        optional: true
         order_weight: 1500
         kind: Generic
 
@@ -148,7 +127,7 @@ generics:
     description: "Generic Network Interface"
     label: Interface
     include_in_menu: false
-    display_label: "{{ name__value }}"
+    display_label: name__value
     order_by:
       - device__name__value
       - name__value
@@ -546,68 +525,6 @@ nodes:
             label: Load Balancer
             description: Load Balancer part of a Fabric.
             color: "#38e7fb"
-
-  - name: VirtualDevice
-    namespace: Dcim
-    description: Generic holding attributes and relationships relevant for virtual device.
-    include_in_menu: false
-    label: Virtual Device
-    icon: mdi:server-network
-    uniqueness_constraints:
-      - [name__value]
-    generate_template: true
-    inherit_from:
-      - CoreArtifactTarget
-      - DcimGenericDevice
-    attributes:
-      - name: role
-        kind: Dropdown
-        optional: true
-        order_weight: 1400
-        choices:
-          - name: core
-            label: Core Router
-            description: Central part of the network.
-            color: "#7f7fff"
-          - name: edge
-            label: Edge Router
-            description: Network boundary with external networks.
-            color: "#bf7fbf"
-          - name: load_balancer
-            label: Load Balancer
-            description: Load Balancer part of a Fabric.
-            color: "#38e7fb"
-          - name: edge_firewall
-            label: Edge Firewall
-            description: "Security boundary with external network"
-            color: "#6a5acd"
-      - name: cpu
-        label: CPU Number
-        kind: Number
-        optional: true
-        order_weight: 2000
-      - name: memory
-        label: Memory Size (GB)
-        kind: Number
-        optional: true
-        order_weight: 2100
-      - name: storage
-        label: Storage Size (GB)
-        kind: Number
-        optional: true
-        order_weight: 2200
-    relationships:
-      - name: device_type
-        peer: DcimDeviceType
-        optional: true
-        cardinality: one
-        kind: Attribute
-        order_weight: 1200
-      - name: hosting_device
-        peer: DcimDevice
-        kind: Attribute
-        cardinality: one
-        optional: true
 
   - name: Physical
     namespace: Interface

--- a/schemas/base/ipam.yml
+++ b/schemas/base/ipam.yml
@@ -12,7 +12,7 @@ nodes:
     include_in_menu: false
     order_by:
       - address__value
-    display_label: "{{ address__value }}"
+    display_label: address__value
     inherit_from:
       - BuiltinIPAddress
     uniqueness_constraints:
@@ -36,7 +36,7 @@ nodes:
     label: Prefix
     order_by:
       - prefix__value
-    display_label: "{{ prefix__value }}"
+    display_label: prefix__value
     inherit_from:
       - BuiltinIPPrefix
     uniqueness_constraints:

--- a/schemas/base/location.yml
+++ b/schemas/base/location.yml
@@ -10,12 +10,11 @@ generics:
     icon: mingcute:location-line
     include_in_menu: true
     hierarchical: true
-    branch: agnostic
     human_friendly_id:
-      - name__value
+      - shortname__value
     order_by:
       - name__value
-    display_label: "{{ name__value }}"
+    display_label: name__value
     attributes:
       - name: name
         kind: Text
@@ -40,15 +39,12 @@ generics:
     description: Location directly hosting device and services.
     include_in_menu: false
     human_friendly_id:
-      - name__value
-    order_by:
-      - name__value
-    display_label: "{{ name__value }}"
+      - shortname__value
     attributes:
-      - name: name
+      - name: shortname
         kind: Text
-        optional: false
-        order_weight: 1000
+        unique: true
+        order_weight: 1100
     # This is only owning relationships toward various assets that could be found on those locations
     relationships:
       - name: prefixes
@@ -59,6 +55,5 @@ generics:
       - name: devices
         label: Devices
         peer: DcimPhysicalDevice
-        identifier: hosting__devices
         cardinality: many
         optional: true

--- a/schemas/base/organization.yml
+++ b/schemas/base/organization.yml
@@ -11,7 +11,7 @@ generics:
       - name__value
     order_by:
       - name__value
-    display_label: "{{ name__value }}"
+    display_label: name__value
     icon: mdi:domain
     include_in_menu: false
     attributes:
@@ -71,74 +71,3 @@ nodes:
     include_in_menu: true
     menu_placement: OrganizationGeneric
 
-  - name: Customer
-    namespace: Organization
-    description: Customer with dedicated network namespace for multi-tenant isolation
-    icon: mdi:account-group
-    inherit_from:
-      - OrganizationGeneric
-    include_in_menu: true
-    menu_placement: OrganizationGeneric
-    attributes:
-      - name: customer_id
-        kind: Text
-        unique: true
-        optional: true
-        description: "Unique customer identifier"
-        order_weight: 900
-      # - name: tenant_type
-      #   kind: Dropdown
-      #   description: "Type of tenancy model"
-      #   choices:
-      #     - name: dedicated
-      #       label: Dedicated Namespace
-      #       description: "Customer has dedicated namespace isolation"
-      #       color: "#2E8B57"
-      #     - name: shared
-      #       label: Shared Namespace
-      #       description: "Customer shares namespace with other tenants"
-      #       color: "#4682B4"
-      #     - name: hybrid
-      #       label: Hybrid
-      #       description: "Customer has both dedicated and shared resources"
-      #       color: "#9370DB"
-      #   default_value: dedicated
-      #   optional: true
-      #   order_weight: 950
-      # - name: size
-      #   kind: Dropdown
-      #   description: "Customer size tier determining resource allocation"
-      #   choices:
-      #     - name: s
-      #       label: Small (S)
-      #       description: "Small customer - limited resources"
-      #       color: "#90EE90"
-      #     - name: m
-      #       label: Medium (M)
-      #       description: "Medium customer - standard resources"
-      #       color: "#87CEEB"
-      #     - name: l
-      #       label: Large (L)
-      #       description: "Large customer - expanded resources"
-      #       color: "#DDA0DD"
-      #     - name: x
-      #       label: Extra Large (X)
-      #       description: "Enterprise customer - maximum resources"
-      #       color: "#F0E68C"
-      #   default_value: m
-      #   optional: true
-      #   order_weight: 1300
-    relationships:
-      - name: ip_prefixes
-        peer: IpamPrefix
-        cardinality: many
-        kind: Component
-        optional: true
-        description: "IP prefixes allocated to this customer"
-        order_weight: 2200
-      - name: namespaces
-        peer: IpamNamespace
-        cardinality: many
-        kind: Component
-        optional: true
-        order_weight: 2000

--- a/schemas/extensions/dcim/generic_device_status.yml
+++ b/schemas/extensions/dcim/generic_device_status.yml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://schema.infrahub.app/infrahub/schema/latest.json
+---
+version: "1.0"
+
+extensions:
+  nodes:
+    - kind: DcimGenericDevice
+      attributes:
+        - name: status
+          kind: Dropdown
+          optional: false
+          order_weight: 1100
+          choices:
+            - name: active
+              label: Active
+              description: Fully operational and currently in service.
+              color: "#7fbf7f"
+            - name: provisioning
+              label: Provisioning
+              description: In the process of being set up and configured.
+              color: "#ffff7f"
+            - name: maintenance
+              label: Maintenance
+              description: Undergoing routine maintenance or repairs.
+              color: "#ffd27f"
+            - name: drained
+              label: Drained
+              description: Temporarily taken out of service.
+              color: "#bfbfbf"

--- a/schemas/extensions/dcim/virtual_device.yml
+++ b/schemas/extensions/dcim/virtual_device.yml
@@ -1,0 +1,66 @@
+# yaml-language-server: $schema=https://schema.infrahub.app/infrahub/schema/latest.json
+---
+version: "1.0"
+
+nodes:
+  - name: VirtualDevice
+    namespace: Dcim
+    description: Generic holding attributes and relationships relevant for virtual device.
+    include_in_menu: false
+    label: Virtual Device
+    icon: mdi:server-network
+    uniqueness_constraints:
+      - [name__value]
+    generate_template: true
+    inherit_from:
+      - CoreArtifactTarget
+      - DcimGenericDevice
+    attributes:
+      - name: role
+        kind: Dropdown
+        optional: true
+        order_weight: 1400
+        choices:
+          - name: core
+            label: Core Router
+            description: Central part of the network.
+            color: "#7f7fff"
+          - name: edge
+            label: Edge Router
+            description: Network boundary with external networks.
+            color: "#bf7fbf"
+          - name: load_balancer
+            label: Load Balancer
+            description: Load Balancer part of a Fabric.
+            color: "#38e7fb"
+          - name: edge_firewall
+            label: Edge Firewall
+            description: "Security boundary with external network"
+            color: "#6a5acd"
+      - name: cpu
+        label: CPU Number
+        kind: Number
+        optional: true
+        order_weight: 2000
+      - name: memory
+        label: Memory Size (GB)
+        kind: Number
+        optional: true
+        order_weight: 2100
+      - name: storage
+        label: Storage Size (GB)
+        kind: Number
+        optional: true
+        order_weight: 2200
+    relationships:
+      - name: device_type
+        peer: DcimDeviceType
+        optional: true
+        cardinality: one
+        kind: Attribute
+        order_weight: 1200
+      - name: hosting_device
+        peer: DcimDevice
+        kind: Attribute
+        cardinality: one
+        optional: true

--- a/schemas/extensions/organization/customer.yml
+++ b/schemas/extensions/organization/customer.yml
@@ -1,0 +1,76 @@
+# yaml-language-server: $schema=https://schema.infrahub.app/infrahub/schema/latest.json
+---
+version: "1.0"
+
+nodes:
+  - name: Customer
+    namespace: Organization
+    description: Customer with dedicated network namespace for multi-tenant isolation
+    icon: mdi:account-group
+    inherit_from:
+      - OrganizationGeneric
+    include_in_menu: true
+    menu_placement: OrganizationGeneric
+    attributes:
+      - name: customer_id
+        kind: Text
+        unique: true
+        optional: true
+        description: "Unique customer identifier"
+        order_weight: 900
+      # - name: tenant_type
+      #   kind: Dropdown
+      #   description: "Type of tenancy model"
+      #   choices:
+      #     - name: dedicated
+      #       label: Dedicated Namespace
+      #       description: "Customer has dedicated namespace isolation"
+      #       color: "#2E8B57"
+      #     - name: shared
+      #       label: Shared Namespace
+      #       description: "Customer shares namespace with other tenants"
+      #       color: "#4682B4"
+      #     - name: hybrid
+      #       label: Hybrid
+      #       description: "Customer has both dedicated and shared resources"
+      #       color: "#9370DB"
+      #   default_value: dedicated
+      #   optional: true
+      #   order_weight: 950
+      # - name: size
+      #   kind: Dropdown
+      #   description: "Customer size tier determining resource allocation"
+      #   choices:
+      #     - name: s
+      #       label: Small (S)
+      #       description: "Small customer - limited resources"
+      #       color: "#90EE90"
+      #     - name: m
+      #       label: Medium (M)
+      #       description: "Medium customer - standard resources"
+      #       color: "#87CEEB"
+      #     - name: l
+      #       label: Large (L)
+      #       description: "Large customer - expanded resources"
+      #       color: "#DDA0DD"
+      #     - name: x
+      #       label: Extra Large (X)
+      #       description: "Enterprise customer - maximum resources"
+      #       color: "#F0E68C"
+      #   default_value: m
+      #   optional: true
+      #   order_weight: 1300
+    relationships:
+      - name: ip_prefixes
+        peer: IpamPrefix
+        cardinality: many
+        kind: Component
+        optional: true
+        description: "IP prefixes allocated to this customer"
+        order_weight: 2200
+      - name: namespaces
+        peer: IpamNamespace
+        cardinality: many
+        kind: Component
+        optional: true
+        order_weight: 2000

--- a/schemas/extensions/security/security.yml
+++ b/schemas/extensions/security/security.yml
@@ -604,6 +604,9 @@ nodes:
     order_by:
       - index__value
     display_label: "{{ name__value }}"
+    human_friendly_id:
+      - policy__name__value
+      - index__value
     uniqueness_constraints:
       - [policy, index__value]
     attributes:

--- a/schemas/extensions/service/segment.yml
+++ b/schemas/extensions/service/segment.yml
@@ -11,6 +11,11 @@ nodes:
     menu_placement: ServiceGenericDevice
     uniqueness_constraints:
       - [deployment, owner, environment__value, customer_name__value]
+    human_friendly_id:
+      - deployment__name__value
+      - owner__name__value
+      - environment__value
+      - customer_name__value
     include_in_menu: true
     inherit_from:
       - ServiceGeneric


### PR DESCRIPTION
## Summary

- Re-align `schemas/base/` toward `opsmill/schema-library` so `base/` stays easier to track against upstream.
- Fix two latent bootstrap failures caused by non-idempotent upserts on `SecurityPolicyRule` and `ServiceNetworkSegment`.
- Adopt the library's `LocationGeneric` / `LocationHosting` model (HFID by `shortname__value`); convert 17 string-form location references in `objects/` from name to shortname.

## Schema changes

- Add `human_friendly_id` to `SecurityPolicyRule` and `ServiceNetworkSegment` so `*Upsert` mutations can match existing rows via composite keys; previously, re-running a partially-completed bootstrap crashed on `Violates uniqueness constraint`.
- Move demo-only nodes out of `base/` into new extension files:
  - `DcimVirtualDevice` → `schemas/extensions/dcim/virtual_device.yml`
  - `OrganizationCustomer` → `schemas/extensions/organization/customer.yml`
- Extract demo-added `DcimGenericDevice.status` to `schemas/extensions/dcim/generic_device_status.yml` (via an `extensions:` block).
- Replace `schemas/base/location.yml` with the library version verbatim. `LocationHosting.name` becomes `shortname`; `branch: agnostic` dropped; paired `hosting__devices` identifier removed from both `DcimPhysicalDevice.location` and `LocationHosting.devices`.
- Cosmetic alignment: unwrap Jinja in `display_label` on `DcimGenericDevice`, `DcimInterface`, `IpamIPAddress`, `IpamPrefix`, `OrganizationGeneric`; add `optional: true` on `DcimConnector.connected_endpoints`.

## Data updates (consequence of Location HFID change)

Converted 17 location references in `objects/` from name to shortname:

| File | Refs |
|---|---|
| `objects/bootstrap/18_devices.yml` | PAR-1 / LON-1 / FRA-1 / BCN-1 / CHI-1 → lowercase shortnames |
| `objects/cloud_security/02_zscaler_devices.yml` | 3× Katowice → ktw |
| `objects/lb/02_lb_devices.yml` | 2× Katowice → ktw |
| `objects/dc/*.yml` | Frankfurt/Katowice/Munich/London/Barcelona → fra/ktw/muc/lon/bcn |
| `objects/pop/*.yml` | London/Chicago → lon/chi |

## Remaining divergence from schema-library

`schemas/base/location.yml` is now identical to upstream. `dcim.yml`, `ipam.yml`, and `organization.yml` still differ — those are demo-specific semantic choices that can't be expressed via `extensions:` (custom role/status choices, composite HFIDs on `DcimDeviceType` / `DcimPlatform`, `IpamIPAddress.interface` removal, `OrganizationManufacturer` redefinition). Candidates for upstream PRs.

## Behavior changes to be aware of

- `LocationGeneric` is no longer `branch: agnostic`. Locations will diff per-branch like everything else.
- The `DcimPhysicalDevice` ↔ `LocationHosting` relationship identifier is now auto-generated; existing device↔location edges in a running DB will migrate on schema reload (fresh bootstrap recommended).

## Test plan

- [ ] `uv run invoke destroy && uv run invoke init` succeeds end-to-end
- [ ] `uv run invoke demo-dc-arista` runs against the new schema and creates the Arista DC topology
- [ ] Re-running `uv run invoke bootstrap` after a successful run is idempotent (no uniqueness-constraint crashes)
- [ ] `uv run pytest tests/unit/` passes
- [ ] Service catalog still loads and can pick a location by shortname in the UI