### PR TITLE
chore: rename bundle-dc references to demo-dc

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -26,10 +26,10 @@ jobs:
 
       - name: Sync folders
         run: |
-          rm -rf target-repo/docs/docs-bundle-dc/*
-          rm -f target-repo/docs/sidebars-bundle-dc.ts
-          cp -r source-repo/docs/docs/* target-repo/docs/docs-bundle-dc/
-          cp source-repo/docs/sidebars.ts target-repo/docs/sidebars-bundle-dc.ts
+          rm -rf target-repo/docs/docs-demo-dc/*
+          rm -f target-repo/docs/sidebars-demo-dc.ts
+          cp -r source-repo/docs/docs/* target-repo/docs/docs-demo-dc/
+          cp source-repo/docs/sidebars.ts target-repo/docs/sidebars-demo-dc.ts
           cd target-repo
           git config user.name github-actions
           git config user.email github-actions@github.com

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 
 ## Project Overview
 
-**bundle-dc** is a comprehensive demonstration of design-driven network automation using [Infrahub](https://docs.infrahub.app). It showcases:
+**demo-dc** is a comprehensive demonstration of design-driven network automation using [Infrahub](https://docs.infrahub.app). It showcases:
 
 - Composable data center and POP topology generation
 - Configuration management with Jinja2 templates

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This repository is demoing the key Infrahub features for an example data center 
 
 ## Running the demo
 
-Documentation for loading and using this demo is available on the Infrahub docs site [docs.infrahub.app/bundle-dc/](https://docs.infrahub.app/bundle-dc)
+Documentation for loading and using this demo is available on the Infrahub docs site [docs.infrahub.app/demo-dc/](https://docs.infrahub.app/demo-dc)
 
 ## Service Catalog
 
@@ -50,7 +50,7 @@ docker-compose up
 
 ### Documentation
 
-For detailed setup instructions, configuration options, and usage guide, see the [bundle-dc docs](https://docs.infrahub.app/bundle-dc).
+For detailed setup instructions, configuration options, and usage guide, see the [demo-dc docs](https://docs.infrahub.app/demo-dc).
 
 ## License
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,5 +1,5 @@
 ---
-# Override file for bundle-dc project
+# Override file for demo-dc project
 # Port configuration via environment variables for running multiple instances:
 #   INFRAHUB_PORT (default: 8000) - Infrahub server
 #   PREFECT_PORT (default: 4200) - Prefect task manager UI

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-This is a [Docusaurus](https://docusaurus.io/) documentation site for the bundle-dc project. It uses a different tech stack than the main Python project.
+This is a [Docusaurus](https://docusaurus.io/) documentation site for the demo-dc project. It uses a different tech stack than the main Python project.
 
 ## Tech Stack
 

--- a/docs/docs/developer-guide.mdx
+++ b/docs/docs/developer-guide.mdx
@@ -512,7 +512,7 @@ uv run pytest tests/unit/
 
 ### Integration tests
 
-Integration tests validate end-to-end workflows by spinning up a complete Infrahub instance, loading schemas and data, and executing realistic user scenarios. These tests ensure that both the bundle-dc code and the Infrahub platform work correctly together.
+Integration tests validate end-to-end workflows by spinning up a complete Infrahub instance, loading schemas and data, and executing realistic user scenarios. These tests ensure that both the demo-dc code and the Infrahub platform work correctly together.
 
 #### How integration tests work
 

--- a/docs/docs/readme.mdx
+++ b/docs/docs/readme.mdx
@@ -1,8 +1,8 @@
 ---
-title: Infrahub bundle-dc example
+title: Infrahub demo-dc example
 ---
 
-Welcome to the Infrahub bundle-dc example. This repository showcases how Infrahub serves as an infrastructure data management platform for managing modern network infrastructure with design-driven automation. It demonstrates Infrahub's core capabilities including:
+Welcome to the Infrahub demo-dc example. This repository showcases how Infrahub serves as an infrastructure data management platform for managing modern network infrastructure with design-driven automation. It demonstrates Infrahub's core capabilities including:
 
 - Schema-driven data modeling
 - Composable topology generation

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -67,7 +67,7 @@ const config: Config = {
       items: [
         {
           type: "docSidebar",
-          sidebarId: "BundleDcSidebar",
+          sidebarId: "DemoDcSidebar",
           position: "left",
           label: "DC Bundle (Extensive PoC)",
         },

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -1,7 +1,7 @@
 import type {SidebarsConfig} from '@docusaurus/plugin-content-docs';
 
 const sidebars: SidebarsConfig = {
-  BundleDcSidebar: [
+  DemoDcSidebar: [
     {
       type: 'category',
       label: 'Getting started',

--- a/objects/bootstrap/19_docs.yml
+++ b/objects/bootstrap/19_docs.yml
@@ -4,8 +4,8 @@ kind: Object
 spec:
   kind: DocsDocs
   data:
-    - name: Bundle-DC Example Docs
-      link: https://docs.infrahub.app/bundle-dc/
+    - name: Demo-DC Example Docs
+      link: https://docs.infrahub.app/demo-dc/
     - name: Infrahub Docs
       link: https://docs.infrahub.app
     - name: Discord Community

--- a/objects/git-repo/github.yml
+++ b/objects/git-repo/github.yml
@@ -4,6 +4,6 @@ kind: Object
 spec:
   kind: CoreReadOnlyRepository
   data:
-    - name: bundle-dc
+    - name: demo-dc
       location: "https://github.com/opsmill/infrahub-demo-dc.git"
       ref: "main"

--- a/objects/git-repo/local-dev.yml
+++ b/objects/git-repo/local-dev.yml
@@ -4,6 +4,6 @@ kind: Object
 spec:
   kind: CoreRepository
   data:
-    - name: bundle-dc
+    - name: demo-dc
       location: "/upstream"
       default_branch: "main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,12 +62,8 @@ disable_error_code = ["union-attr", "type-abstract"]
 module = ["untyped_package.*"]
 follow_untyped_imports = true
 
-[tool.rumdl]
-extend = true
-MD013 = false
-MD029 = false
-MD033 = false
-MD041 = false
+[tool.rumdl.global]
+disable = ["MD013", "MD029", "MD033", "MD041"]
 exclude = [
     ".claude/",
     ".git/",
@@ -81,7 +77,7 @@ exclude = [
     "docs/README.md",
     "node_modules/",
 ]
-respect_gitignore = true
+respect-gitignore = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -3,7 +3,7 @@
 Bootstrap Infrahub with schemas, data, and configurations.
 
 This script automates the complete setup of an Infrahub instance with all necessary
-data for the bundle-dc demonstration environment. It performs a sequential bootstrap
+data for the demo-dc demonstration environment. It performs a sequential bootstrap
 process with visual feedback and error handling.
 
 Bootstrap Process (7 steps):
@@ -14,7 +14,7 @@ Bootstrap Process (7 steps):
                          manufacturers, device types, ASNs, IP prefixes, pools, designs)
 4. Load Security Data - Create security zones, policies, and rules
 5. Create Users & Roles - Set up user accounts (emma, otto) with permissions
-6. Add Repository - Register bundle-dc Git repository (local or GitHub)
+6. Add Repository - Register demo-dc Git repository (local or GitHub)
 7. Load Event Actions - Configure automation triggers (optional, may need repository sync)
 
 Features:
@@ -305,7 +305,7 @@ def main(branch: str = "main") -> int:
 
     This is the primary orchestrator function that coordinates all bootstrap steps
     in the correct sequence. It provides a complete, automated setup of Infrahub
-    with all necessary schemas, data, and configurations for the bundle-dc demo.
+    with all necessary schemas, data, and configurations for the demo-dc demo.
 
     Bootstrap Sequence:
     ===================
@@ -316,7 +316,7 @@ def main(branch: str = "main") -> int:
     5. Load bootstrap data (locations, platforms, roles, devices, etc.)
     6. Load security data (zones, policies, rules)
     7. Create user accounts and roles (emma, otto)
-    8. Add bundle-dc Git repository (local or GitHub)
+    8. Add demo-dc Git repository (local or GitHub)
     9. Wait for repository sync (120 seconds)
     10. Load event actions (optional - may fail if repo not synced)
     11. Display success message with next steps
@@ -367,14 +367,14 @@ def main(branch: str = "main") -> int:
     console.print()
     console.print(
         Panel(
-            f"[bold bright_blue]🚀 Infrahub bundle-dc Bootstrap[/bold bright_blue]\n"
+            f"[bold bright_blue]🚀 Infrahub demo-dc Bootstrap[/bold bright_blue]\n"
             f"[bright_cyan]Branch:[/bright_cyan] [bold yellow]{branch}[/bold yellow]\n\n"
             "[dim]This will load:[/dim]\n"
             "  [blue]•[/blue] Schemas\n"
             "  [magenta]•[/magenta] Menu definitions\n"
             "  [yellow]•[/yellow] Bootstrap data\n"
             "  [green]•[/green] Security data\n"
-            "  [bright_magenta]•[/bright_magenta] bundle-dc repository",
+            "  [bright_magenta]•[/bright_magenta] demo-dc repository",
             border_style="bright_blue",
             box=box.SIMPLE,
             title="[bold bright_blue]Bootstrap Process[/bold bright_blue]",
@@ -453,12 +453,12 @@ def main(branch: str = "main") -> int:
     # ========================================================================
     # Step 6: Add Git Repository
     # ========================================================================
-    # This step adds the bundle-dc Git repository to Infrahub, which contains
+    # This step adds the demo-dc Git repository to Infrahub, which contains
     # Python generators and transforms needed for topology creation and
     # configuration generation. This step may fail gracefully if the repository
     # already exists from a previous bootstrap run.
     msg = "\n[bold bright_magenta on black][6/7][/bold bright_magenta on black] "
-    msg += "📚 [bold white]Adding bundle-dc repository[/bold white]"
+    msg += "📚 [bold white]Adding demo-dc repository[/bold white]"
     console.print(msg)
 
     # Choose repository source based on INFRAHUB_GIT_LOCAL environment variable

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-This directory contains the test suite for bundle-dc, using pytest as the test framework. Tests are organized into unit tests (fast, isolated) and integration tests (require running Infrahub instance).
+This directory contains the test suite for demo-dc, using pytest as the test framework. Tests are organized into unit tests (fast, isolated) and integration tests (require running Infrahub instance).
 
 ## Test Commands
 


### PR DESCRIPTION
## Summary
- Repo is now `infrahub-demo-dc` and docs site has moved to https://docs.infrahub.app/demo-dc — update all in-repo references to match.
- Covers: README, AGENTS.md files, Docusaurus docs + sidebar id, bootstrap script messages, git-repo object `name`, docs link bootstrap object, sync-docs workflow paths, and docker-compose override header.

## Follow-ups required outside this PR
- `opsmill/infrahub-docs` — rename `docs/docs-bundle-dc/` to `docs/docs-demo-dc/` and `docs/sidebars-bundle-dc.ts` to `docs/sidebars-demo-dc.ts`, or the sync workflow will create an orphan folder on next push.
- Any live Infrahub instance already holding a repo record under `name: bundle-dc` needs the old record removed before re-bootstrapping — the renamed record will otherwise collide/orphan.

## Test plan
- [ ] `uv run invoke lint` passes locally
- [ ] `uv run invoke init` completes end-to-end against a clean Infrahub instance (verifies bootstrap script messages and repo-add step)
- [ ] Docusaurus build succeeds (`npm --prefix docs run build`) with the renamed `DemoDcSidebar`
- [ ] After merge, confirm `sync-docs.yml` pushes into the renamed folders in `opsmill/infrahub-docs`